### PR TITLE
Colour very low

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -6,23 +6,22 @@
 
 
 @if ($Wiki_post_background_color == ""){
-    $Wiki_post_background_color: var(--primary-low, $primary-low);
+    $Wiki_post_background_color: var(--primary-very-low, $primary-very-low);
 }
-
 @if $Wiki_post_background_color == "primary" {
-    $Wiki_post_background_color: var(--primary-low, $primary-low);
+    $Wiki_post_background_color: var(--primary-very-low, $primary-very-low);
 }
 @if $Wiki_post_background_color == "secondary" {
-    $Wiki_post_background_color: var(--secondary-low, $secondary-low);
+    $Wiki_post_background_color: var(--secondary-very-low, $secondary-very-low);
 }
 @if $Wiki_post_background_color == "tertiary" {
-    $Wiki_post_background_color: var(--tertiary-low, $tertiary-low);
+    $Wiki_post_background_color: var(--tertiary-very-low, $tertiary-very-low);
 }
 @if $Wiki_post_background_color == "quaternary" {
     $Wiki_post_background_color: var(--quaternary-low, $quaternary-low);
 }
 @if $Wiki_post_background_color == "header-background" {
-    $Wiki_post_background_color: var(--header-background-low, $header-background-low);
+    $Wiki_post_background_color: var(--header-background, $header-background);
 }
 @if $Wiki_post_background_color == "header-primary" {
     $Wiki_post_background_color: var(--header-primary-low, $header-primary-low);
@@ -42,23 +41,23 @@
 
 
 @if ($Shared_edits_background_color == ""){
-    $Shared_edits_background_color: var(--primary-low, $primary-low);
+    $Shared_edits_background_color: var(--highlight-low, $highlight-low);
 }
 
 @if $Shared_edits_background_color == "primary" {
-    $Shared_edits_background_color: var(--primary-low, $primary-low);
+    $Shared_edits_background_color: var(--primary-very-low, $primary-very-low);
 }
 @if $Shared_edits_background_color == "secondary" {
-    $Shared_edits_background_color: var(--secondary-low, $secondary-low);
+    $Shared_edits_background_color: var(--secondary-very-low, $secondary-very-low);
 }
 @if $Shared_edits_background_color == "tertiary" {
-    $Shared_edits_background_color: var(--tertiary-low, $tertiary-low);
+    $Shared_edits_background_color: var(--tertiary-very-low, $tertiary-very-low);
 }
 @if $Shared_edits_background_color == "quaternary" {
     $Shared_edits_background_color: var(--quaternary-low, $quaternary-low);
 }
 @if $Shared_edits_background_color == "header-background" {
-    $Shared_edits_background_color: var(--header-background-low, $header-background-low);
+    $Shared_edits_background_color: var(--header-background, $header-background);
 }
 @if $Shared_edits_background_color == "header-primary" {
     $Shared_edits_background_color: var(--header-primary-low, $header-primary-low);

--- a/common/common.scss
+++ b/common/common.scss
@@ -41,7 +41,7 @@
 
 
 @if ($Shared_edits_background_color == ""){
-    $Shared_edits_background_color: var(--highlight-low, $highlight-low);
+    $Shared_edits_background_color: var(--tertiary-very-low, $tertiary-very-low);
 }
 
 @if $Shared_edits_background_color == "primary" {

--- a/common/common.scss
+++ b/common/common.scss
@@ -4,7 +4,6 @@
 /* $wiki_added_text: defined as theme setting */
 /* $Shared_edits_added_text: defined as theme setting */
 
-
 @if ($Wiki_post_background_color == ""){
     $Wiki_post_background_color: var(--primary-very-low, $primary-very-low);
 }

--- a/settings.yml
+++ b/settings.yml
@@ -5,7 +5,7 @@ Wiki_post_background_color:
 
 Shared_edits_background_color:
   type: string
-  default: 'highlight'
+  default: 'tertiary'
   description: 'Enter a background color for Shared Edits posts.<br>Choose any Scheme color (primary, secondary, tertiary, quaternary, header background, header primary, highlight, danger, success, love)<br>You can also use HTML color codes (e.g. #abc123) or names (e.g. red)<br>Note: applies a low variant of the variable chosen'
 
 Wiki_added_text:

--- a/settings.yml
+++ b/settings.yml
@@ -1,12 +1,12 @@
 Wiki_post_background_color:
   type: string
   default: 'primary'
-  description: 'Enter a background color for your Wiki posts.<br>Choose any Scheme color (primary, secondary, tertiary, quaternary, header background, header primary, highlight, danger, success, love)<br>You can also use HTML color codes (e.g. #abc123) or names (e.g. red)'
+  description: 'Enter a background color for your Wiki posts.<br>Choose any Scheme color (primary, secondary, tertiary, quaternary, header background, header primary, highlight, danger, success, love)<br>You can also use HTML color codes (e.g. #abc123) or names (e.g. red)<br>Note: applies a low variant of the variable chosen'
 
 Shared_edits_background_color:
   type: string
   default: 'highlight'
-  description: 'Enter a background color for Shared Edits posts.<br>Choose any Scheme color (primary, secondary, tertiary, quaternary, header background, header primary, highlight, danger, success, love)<br>You can also use HTML color codes (e.g. #abc123) or names (e.g. red)'
+  description: 'Enter a background color for Shared Edits posts.<br>Choose any Scheme color (primary, secondary, tertiary, quaternary, header background, header primary, highlight, danger, success, love)<br>You can also use HTML color codes (e.g. #abc123) or names (e.g. red)<br>Note: applies a low variant of the variable chosen'
 
 Wiki_added_text:
   type: string


### PR DESCRIPTION
Makes it so that @mentions aren't obscured in wikis, and reduced the intensity of the background color where possible.

Also changed default Shared Edits colour to Tertiary-very-low.